### PR TITLE
Add voice models documentation page

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -74,6 +74,10 @@
             ]
           },
           {
+            "group": "Models",
+            "pages": ["models/voice"]
+          },
+          {
             "group": "Common Issues",
             "pages": [
               "common-issues/troubleshooting",

--- a/docs.json
+++ b/docs.json
@@ -74,10 +74,6 @@
             ]
           },
           {
-            "group": "Models",
-            "pages": ["models/voice"]
-          },
-          {
             "group": "Common Issues",
             "pages": [
               "common-issues/troubleshooting",

--- a/models/language.mdx
+++ b/models/language.mdx
@@ -1,0 +1,42 @@
+Language models take your transcribed text and enhance, format, or transform it using AI. There are two types of language models: local and cloud-based. Local (or Offline) models run on your machine. Cloud models are hosted either by Superwhisper or another provider.
+
+## Superwhisper (Cloud)
+
+These are the language models that are hosted in the Cloud by Superwhisper. They are optimized for low latency and high quality text processing.
+
+| Name                | Speed | Benchmark (0-100) | Size  | License |
+| ------------------- | ----- | ----------------- | ----- | ------- |
+| S1-Language (Cloud) | 10    | 82                | Cloud | Pro     |
+
+## Anthropic (Cloud)
+
+Anthropic's Claude models available through Superwhisper. Usage is covered by your license.
+
+| Name              | Speed | Benchmark (0-100) | Size  | License |
+| ----------------- | ----- | ----------------- | ----- | ------- |
+| Claude 4.5 Sonnet | 8     | 87                | Cloud | Pro     |
+| Claude 4 Sonnet   | 8     | 87                | Cloud | Pro     |
+| Claude 3.7 Sonnet | 8     | 85                | Cloud | Pro     |
+| Claude 3.5 Sonnet | 8     | 89                | Cloud | Pro     |
+| Claude 3.5 Haiku  | 9     | 75                | Cloud | Pro     |
+
+## OpenAI (Cloud)
+
+OpenAI's latest GPT models available through Superwhisper. Usage is covered by your license.
+
+| Name         | Speed | Benchmark (0-100) | Size  | License |
+| ------------ | ----- | ----------------- | ----- | ------- |
+| GPT-5        | 7     | 91                | Cloud | Pro     |
+| GPT-5 mini   | 8     | 87                | Cloud | Pro     |
+| GPT-5 nano   | 9     | 83                | Cloud | Pro     |
+| GPT-4.1      | 7     | 90                | Cloud | Pro     |
+| GPT-4.1 mini | 8     | 86                | Cloud | Pro     |
+| GPT-4.1 nano | 9     | 80                | Cloud | Pro     |
+
+## Groq (Cloud)
+
+Ultra-fast inference using Groq's LPU technology. Usage is covered by your license.
+
+| Name       | Speed | Benchmark (0-100) | Size  | License |
+| ---------- | ----- | ----------------- | ----- | ------- |
+| Llama 3 8b | 10    | 80                | Cloud | Pro     |

--- a/models/voice.mdx
+++ b/models/voice.mdx
@@ -1,12 +1,13 @@
+Voice models take your recorded voice and transcribe them into text. There are two types of voice models: local and cloud-based. Local (or Offline) models run on your machine. Cloud models are hosted either by Superwhisper or another provider.
 
 ## Superwhisper (Cloud)
 
 These are the models that are hosted in the Cloud by Superwhisper. They are optimized for low latency and accuracy, and are available for use in 100+ languages.
 
-| Name          | Lang  | Translate | Speed | Accuracy | Size  | License |
-| ------------- | ----- | --------- | ----- | -------- | ----- | ------- |
-| Max (Cloud)   | multi | ✔         | 10    | 9        | Cloud | Pro     |
-| Ultra (Cloud) | multi | ✔         | 9     | 9        | Cloud | Pro     |
+| Name            | Lang  | Translate | Speed | Accuracy | Size  | License |
+| --------------- | ----- | --------- | ----- | -------- | ----- | ------- |
+| Voice-1 (Cloud) | multi | ✔        | 10    | 9        | Cloud | Pro     |
+| Ultra (Cloud)   | multi | ✔        | 9     | 9        | Cloud | Pro     |
 
 ## Whisper Models (Local)
 
@@ -26,7 +27,6 @@ They are based on the [Whisper](https://github.com/openai/whisper) model series 
 | Nano (English)           | en   | ✖        | 9     | 3        | 150 MB | Free    |
 | Fast                     | all  | ✔        | 10    | 1        | 75 MB  | Free    |
 | Fast (English)           | en   | ✖        | 10    | 1        | 75 MB  | Free    |
-
 
 ## Nvidia Parakeet (Local)
 

--- a/models/voice.mdx
+++ b/models/voice.mdx
@@ -1,0 +1,48 @@
+
+## Superwhisper (Cloud)
+
+These are the models that are hosted in the Cloud by Superwhisper. They are optimized for low latency and accuracy, and are available for use in 100+ languages.
+
+| Name          | Lang  | Translate | Speed | Accuracy | Size  | License |
+| ------------- | ----- | --------- | ----- | -------- | ----- | ------- |
+| Max (Cloud)   | multi | ✔         | 10    | 9        | Cloud | Pro     |
+| Ultra (Cloud) | multi | ✔         | 9     | 9        | Cloud | Pro     |
+
+## Whisper Models (Local)
+
+These models run on your machine, allowing you to transcribe audio without relying on external services.
+They are based on the [Whisper](https://github.com/openai/whisper) model series from OpenAI. They run locally using [whisper.cpp](https://github.com/ggerganov/whisper.cpp).
+
+| Name                     | Lang | Translate | Speed | Accuracy | Size   | License |
+| ------------------------ | ---- | --------- | ----- | -------- | ------ | ------- |
+| Ultra V3 Turbo           | all  | ✔        | 8     | 8        | 1.6 GB | Pro     |
+| Ultra                    | all  | ✔        | 6     | 10       | 3 GB   | Pro     |
+| Ultra V3 Turbo (Chinese) | zh   | ✖        | 8     | 8        | 1.6 GB | Pro     |
+| Pro                      | all  | ✔        | 7     | 8        | 1.5 GB | Pro     |
+| Pro (English)            | en   | ✖        | 7     | 8        | 1.5 GB | Pro     |
+| Standard                 | all  | ✔        | 8     | 5        | 500 MB | Free    |
+| Standard (English)       | en   | ✖        | 8     | 5        | 500 MB | Free    |
+| Nano                     | all  | ✔        | 9     | 3        | 150 MB | Free    |
+| Nano (English)           | en   | ✖        | 9     | 3        | 150 MB | Free    |
+| Fast                     | all  | ✔        | 10    | 1        | 75 MB  | Free    |
+| Fast (English)           | en   | ✖        | 10    | 1        | 75 MB  | Free    |
+
+
+## Nvidia Parakeet (Local)
+
+They are based on the [Parakeet](https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2) model. They run locally (on your laptop) using Argmax's [WhisperKit SDK](https://github.com/argmaxinc/whisperkit). They are extremely fast and run in parallel over long recordings. Drawbacks here are they do tend to struggle with punctuation and have minor hallucination issues with single word recordings.
+
+| Name                   | Lang  | Translate | Speed | Accuracy | Size   | License |
+| ---------------------- | ----- | --------- | ----- | -------- | ------ | ------- |
+| Parakeet               | en    | ✖        | 10    | 8        | 476 MB | Pro     |
+| Parakeet Multilanguage | multi | ✖        | 10    | 8        | 494 MB | Pro     |
+
+## Deepgram (Cloud)
+
+The Nova series of models are a Cloud model hosted by Deepgram.
+
+| Name         | Lang  | Trans. | Speed | Accuracy | Size  | License |
+| ------------ | ----- | ------ | ----- | -------- | ----- | ------- |
+| Nova 3       | multi | –      | 7     | 8        | Cloud | Pro     |
+| Nova 2       | multi | –      | 7     | 7        | Cloud | Pro     |
+| Nova Medical | en    | –      | 10    | 7        | Cloud | Pro     |

--- a/models/voice.mdx
+++ b/models/voice.mdx
@@ -4,10 +4,10 @@ Voice models take your recorded voice and transcribe them into text. There are t
 
 These are the models that are hosted in the Cloud by Superwhisper. They are optimized for low latency and accuracy, and are available for use in 100+ languages.
 
-| Name            | Lang  | Translate | Speed | Accuracy | Size  | License |
-| --------------- | ----- | --------- | ----- | -------- | ----- | ------- |
-| Voice-1 (Cloud) | multi | ✔        | 10    | 9        | Cloud | Pro     |
-| Ultra (Cloud)   | multi | ✔        | 9     | 9        | Cloud | Pro     |
+| Name             | Lang  | Translate | Speed | Accuracy | Size  | License |
+| ---------------- | ----- | --------- | ----- | -------- | ----- | ------- |
+| S1-Voice (Cloud) | multi | ✔        | 10    | 9        | Cloud | Pro     |
+| Ultra (Cloud)    | multi | ✔        | 9     | 9        | Cloud | Pro     |
 
 ## Whisper Models (Local)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "superwhisper-docs",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
Introduces models/voice.mdx with details on available voice models, including Superwhisper, Whisper, Nvidia Parakeet, and Deepgram. Updates docs.json to include the new page under a 'Models' group.